### PR TITLE
docs: turbo4 4.125 bpw + Jun-2026 rematch writeup; pin 3/4-bit centroid values

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Additional experiments and writeups: [Sparse V dequant](docs/papers/sparse-v-deq
 |------------|----------|-------------|----------------------|---------|
 | f16 | 16.0 | 1.0x | 6.121 | -0.16% |
 | q8_0 | 8.5 | 1.9x | 6.111 | baseline |
-| **turbo4** | **4.25** | **3.8x** | **6.125** | **+0.23%** |
+| **turbo4** | **4.125** | **3.9x** | **6.125** | **+0.23%** |
 | q4_0 | 4.5 | 3.6x | 6.142 | +0.52% |
 | turbo3 | 3.5† | 4.6x† | 6.176 | +1.06% |
 | turbo2 | 2.5 | 6.4x | 6.507 | +6.48% |
@@ -91,7 +91,7 @@ The fastest path is a [prebuilt binary](https://github.com/TheTom/llama-cpp-turb
 | Flag | Bits/val | Compression vs fp16 | Description |
 |------|----------|--------------------:|-------------|
 | `turbo3` | 3.5† | **4.6x**† | 3-bit PolarQuant + WHT rotation. Best compression, q8_0 speed. |
-| `turbo4` | 4.25 | **3.8x** | 4-bit PolarQuant (16 centroids). Best quality. |
+| `turbo4` | 4.125 | **3.9x** | 4-bit PolarQuant (16 centroids). Best quality. |
 | `q8_0` | 8 | 2.0x | llama.cpp default quantized cache. |
 | `q4_0` | 4 | 4.0x | llama.cpp 4-bit cache. |
 
@@ -111,7 +111,7 @@ Input: KV cache vector x ∈ R^d (one attention head)
     │   turbo4: 16 centroids (4-bit), turbo3: 8 centroids (3-bit), turbo2: 4 centroids (2-bit)
     │
     └── Output: quantized indices + norm per block
-        Compression: 3.8x (turbo4), 5.1x (turbo3), 7.5x (turbo2)
+        Compression: 3.9x (turbo4), 5.1x (turbo3), 7.5x (turbo2)
 ```
 
 > **Note on QJL: reference only, not used in production.**
@@ -195,6 +195,7 @@ docs/
 ## Docs
 
 - [Benchmarks](docs/benchmarks.md) — full quality/speed/retrieval data, community hardware results
+- [turbo4 Rematch (Jun 2026)](docs/turbo4-rematch-2026-06.md) — centroid-port-bug fix, 4.125 bpw, PDL + fused-MMA decode, asymmetric KLD; head-to-head vs `spiritbuun`
 - [MLX Port](docs/mlx-port.md) — the experimental MLX Python port: results, quickstarts, MM-NIAH
 - [Changelog](docs/changelog.md) — v1 milestone history
 - [Quality Benchmarks](docs/quality-benchmarks.md) — perplexity validation, bisection log

--- a/docs/turbo4-rematch-2026-06.md
+++ b/docs/turbo4-rematch-2026-06.md
@@ -31,4 +31,17 @@ Consistent with the K-dominates-KLD finding: **q8_0-K + turbo4-V (~6.3 bpw) cuts
 
 ## Cross-backend
 
-The changes compile cleanly under HIP/ROCm on an RX 9070 XT (gfx1201, ROCm 7.1), including the new turbo-MMA instances; the MMA decode path is gated to CUDA tensor cores and falls back to VEC on AMD. (turbo3/turbo2 are regression-free; their decode-at-depth still uses VEC — extending the MMA gate to them is straightforward follow-up.)
+The changes compile cleanly under HIP/ROCm on an RX 9070 XT (gfx1201, ROCm 7.1), including the new turbo-MMA instances; the MMA decode path is gated to CUDA tensor cores and falls back to VEC on AMD.
+
+## turbo3 / turbo2 also on the fused MMA path
+
+The same GQA-packed MMA decode was extended from turbo4-only to turbo3 and turbo2 (per-type tile loaders: the 3-bit split index = 2 low bits in `qs` + 1 high bit in `signs`, and the plain 2-bit unpack). It is bit-exact to the VEC path (Mean KLD @2048 chunks=8: turbo3 `0.020278 == 0.020278`, turbo2 `0.041490 == 0.041490`), and removes the at-depth decode collapse those configs had on VEC. Decode tg32 (RTX 5090, qwen3.6-35B-A3B), now flat and ahead of the reference fork at every depth:
+
+| depth | turbo3 (ours / ref) | turbo2 (ours / ref) |
+|------:|:-------------------:|:-------------------:|
+| 2048  | **224** / 193 | **228** / 213 |
+| 8192  | **225** / 193 | **224** / 210 |
+| 16384 | **217** / 183 | **217** / 204 |
+| 32768 | **203** / 178 | **203** / 200 |
+
+(Pre-MMA VEC decayed to 124 / 183 at 32K respectively — losing to the ref fork there. turbo3 also gets the corrected Lloyd-Max centroids: Mean KLD @2048 −4.3%.)

--- a/docs/turbo4-rematch-2026-06.md
+++ b/docs/turbo4-rematch-2026-06.md
@@ -1,0 +1,34 @@
+# turbo4 improvements & cross-fork rematch (June 2026)
+
+A round of turbo4 KV-cache work in [llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) ([PR #197](https://github.com/TheTom/llama-cpp-turboquant/pull/197)), benchmarked head-to-head against the strongest external turbo4 fork (`spiritbuun/master`) on one RTX 5090. Both forks built from source; symmetric turbo4; Qwen3.6-35B-A3B (Q4_K_XL); KL divergence vs an f16-KV reference over 32768 tokens/depth.
+
+## Result (both forks 4.125 bpw)
+
+| depth | Mean KLD (ours / ref) | prefill t/s (ours / ref) | decode t/s (ours / ref) |
+|------:|:---------------------:|:------------------------:|:-----------------------:|
+| 2048  | **0.00930** / 0.00953 | **8334** / 8110 | **223** / 205 |
+| 8192  | **0.00741** / 0.00753 | **8051** / 7984 | **222** / 200 |
+| 16384 | **0.00840** / 0.00857 | **7760** / 7715 | **206** / 194 |
+| 32768 | **0.00793** / 0.00796 | 7265 / 7297 | **189** / 188 |
+
+Lower KLD at every depth; higher decode at every depth; higher prefill at 2048/8192/16384, dead-heat at 32768.
+
+## What changed
+
+1. **Corrected the 4-bit Lloyd-Max centroid table.** The *Python reference here was always correct* (`codebook.py` → `_lloyds_gaussian(16, σ=1/√d)`), but the C/CUDA port had drifted to a hardcoded table fit to σ≈0.064 — ~0.61× too narrow for the post-FWHT N(0,1/128) envelope (outer 0.1739 vs correct 0.2402). That clipped ~4.9% of the rotated tails → ~2.1× excess quantization MSE, inflating both PPL and the q·k logit variance (KLD). Re-deriving from the reference cut Mean KLD ~33%. A new regression test (`tests/test_codebook.py::test_4bit_centroids_pinned`, and the 3-bit equivalent) now pins the correct envelope so a port can be checked against it.
+
+2. **Dropped a dead `rnorm` field → 4.125 bpw.** The C 4-bit block carried an unused fp16 `rnorm` (only the legacy 3-bit+QJL path reads it). The reference never had it; removing it from the port makes the block 66 B = 4.125 bpw, bit-identical quality. (README updated: turbo4 is 4.125 bpw / 3.9×, not 4.25 / 3.8×.)
+
+3. **Fixed a perplexity-tool int32 overflow** (`i*nv` / `n_token*nv` indexing) that SIGSEGV'd KL-divergence runs at n_ctx ≥ ~28K — this was the "SEGV @ 32K" some comparison tables show, not an inference crash.
+
+4. **Backported Programmatic Dependent Launch** (upstream #22522) — closes the decode kernel-launch-latency gap on Blackwell (helps f16 and turbo decode, quality-neutral).
+
+5. **Fused turbo4 MMA decode path** — routes turbo4 token-generation onto the GQA-packed tensor-core kernel (inline dequant in the WHT-rotated domain). With grouped-query attention this reads each KV element once per head-group instead of per query head, which flattens decode at depth. Quality-neutral (KLD identical; divergence is f16 reduction-order noise, the same that separates f16-MMA from f16-VEC).
+
+## Asymmetric quality config
+
+Consistent with the K-dominates-KLD finding: **q8_0-K + turbo4-V (~6.3 bpw) cuts Mean KLD ~26%** vs symmetric turbo4 (−28% vs the reference fork), growing with depth. f16-K buys nothing further (K saturates at q8_0; the residual KLD is all V-side), so q8_0-K is the efficient K. Caveat: "V is free" holds at turbo4 (4-bit) but **breaks at turbo2** — q8_0-K + turbo2-V regresses KLD ~2.4× (the 2-bit V error dominates).
+
+## Cross-backend
+
+The changes compile cleanly under HIP/ROCm on an RX 9070 XT (gfx1201, ROCm 7.1), including the new turbo-MMA instances; the MMA decode path is gated to CUDA tensor cores and falls back to VEC on AMD. (turbo3/turbo2 are regression-free; their decode-at-depth still uses VEC — extending the MMA gate to them is straightforward follow-up.)

--- a/tests/test_codebook.py
+++ b/tests/test_codebook.py
@@ -30,6 +30,42 @@ class TestOptimalCentroids:
             assert len(centroids) == 4
             np.testing.assert_allclose(centroids, expected, rtol=1e-10)
 
+    def test_3bit_centroids_pinned(self):
+        """3-bit optimal centroids for d=128 (the canonical KV block size).
+
+        Reference values every backend port (CUDA/HIP/Metal/CPU) must reproduce.
+        A mismatch here — or a port hardcoding different values — means a
+        mis-scaled codebook that clips the post-rotation Gaussian tails and
+        inflates KLD/PPL. Pinned to guard against transcription drift.
+        """
+        from turboquant.codebook import optimal_centroids
+
+        c = optimal_centroids(3, 128)
+        expected = np.array([
+            -0.19021, -0.11879, -0.06682, -0.02166,
+             0.02166,  0.06682,  0.11879,  0.19021,
+        ])
+        np.testing.assert_allclose(c, expected, atol=5e-4)
+
+    def test_4bit_centroids_pinned(self):
+        """4-bit optimal centroids for d=128.
+
+        Outer level ≈ 0.2402 (2.72·σ, σ=1/√128). A downstream C/CUDA port once
+        shipped ≈0.1739 (σ≈0.064, 0.61× too narrow) → ~2.1× excess MSE and a
+        large KLD regression. This test pins the correct envelope so any port
+        can be checked against it.
+        """
+        from turboquant.codebook import optimal_centroids
+
+        c = optimal_centroids(4, 128)
+        expected = np.array([
+            -0.24021, -0.18139, -0.14149, -0.10960,
+            -0.08205, -0.05709, -0.03369, -0.01114,
+             0.01114,  0.03369,  0.05709,  0.08205,
+             0.10960,  0.14149,  0.18139,  0.24021,
+        ])
+        np.testing.assert_allclose(c, expected, atol=5e-4)
+
     def test_centroids_sorted(self):
         """Centroids should always be sorted ascending."""
         from turboquant.codebook import optimal_centroids


### PR DESCRIPTION
Research-repo counterpart to [llama-cpp-turboquant#197](https://github.com/TheTom/llama-cpp-turboquant/pull/197). Factual fixes + a writeup + a regression test, no algorithm change (the Python reference was already correct).

## Changes
- **README:** turbo4 is **4.125 bpw / 3.9×**, not 4.25 / 3.8× — the no-QJL 4-bit block is `norm(fp16) + 64 B indices = 66 B`; the old number counted a phantom `rnorm`. (The C/CUDA port also dropped that dead field.)
- **`docs/turbo4-rematch-2026-06.md`:** the June-2026 turbo4 work + head-to-head vs `spiritbuun/master` (KLD/prefill/decode at 4.125 bpw), the centroid-port-bug story, PDL backport + fused-MMA decode, and the asymmetric q8_0-K + turbo4-V result (−26% KLD; "V is free" holds at 4-bit, breaks at 2-bit).
- **`tests/test_codebook.py`:** pin the exact 3-bit and 4-bit optimal centroids for d=128. The suite previously pinned 1-bit/2-bit but only sanity-checked 3/4-bit — exactly the gap that let a downstream C/CUDA port drift to a mis-scaled 4-bit table (outer 0.1739 vs correct 0.2402, ~2.1× excess MSE). Now any port can be checked against these.

## Notes
- The Python reference codebook was correct throughout; this is documentation + a guard, not a fix to `optimal_centroids`.
- `pytest tests/test_codebook.py` → 26 passed.
